### PR TITLE
fix(qscmf-formitem-object-storage): 修复腾讯云 COS 文件上传时 Content-Type 未设置的…

### DIFF
--- a/src/Lib/Vendor/TengxunCos.php
+++ b/src/Lib/Vendor/TengxunCos.php
@@ -7,7 +7,6 @@ namespace FormItem\ObjectStorage\Lib\Vendor;
 use FormItem\ObjectStorage\Lib\Common;
 use FormItem\ObjectStorage\Lib\UploadConfig;
 use GuzzleHttp\Psr7\Utils;
-use Tos\Model\PutObjectFromFileInput;
 
 class TengxunCos implements IVendor
 {
@@ -316,6 +315,7 @@ class TengxunCos implements IVendor
 
         $upload_meta = $this->getUploadConfig()->getMeta();
         $upload_meta = Common::injectMeta($upload_meta, $get_data);
+        $upload_meta['Content-Type'] = $get_data['file_type'];
 
         $authorization=$this->getAuthorization($pathname,'POST');
 


### PR DESCRIPTION
…问题- 在上传文件时，从 get_data 中获取 file_type 并设置为 Content-Type

- 确保文件以正确的类型上传到腾讯云 COS