### PR TITLE
feat(Common): 支持自定义回调地址配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -789,3 +789,7 @@ $res = $os_vendor->genClient('image')->uploadFile($file_path, $object, $options)
 ## 迁移说明
 
 若文件表不为 `qs_file_pic`，则使用 `.env` 文件配置 `OBJECT_STORAGE_FILE_TABLE_NAME` 来指定文件表名。
+
+## 自定义回调地址
+
+`.env` 文件中加入配置项 `OBJECT_STORAGE_CALLBACK_URL`，如：`OBJECT_STORAGE_CALLBACK_URL=http://your_domain.com/extends/ObjectStorage/callBack`

--- a/src/Lib/Common.php
+++ b/src/Lib/Common.php
@@ -97,7 +97,9 @@ class Common
         !$jump && $params['jump'] = '0';
 
         $query = http_build_query($params);
-        return U('/extends/ObjectStorage/callBack',[],true,true).'?'.$query;
+        // return U('/extends/ObjectStorage/callBack',[],true,true).'?'.$query;
+        $site_url = env('OBJECT_STORAGE_CALLBACK_URL', U('/extends/ObjectStorage/callBack',[],true,true));
+        return $site_url.'?'.$query;
     }
 
     public static function extractParams(array $get_data):array{


### PR DESCRIPTION
在 `.env` 文件中新增 `OBJECT_STORAGE_CALLBACK_URL` 配置项，用于指定对象存储的回调地址。 当未配置时，默认使用系统生成的回调地址。
更新 README 文档，添加相关配置说明。