### PR TITLE
feat(Common): 支持自定义对象存储回调地址

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,4 +666,6 @@ $res = $os_vendor->genClient('image')->uploadFile($file_path, $object, $options)
    - uploadError : 上传出错
    - deleteFile : 删除图片
    
-   
+## 自定义回调地址
+
+`.env` 文件中加入配置项 `OBJECT_STORAGE_CALLBACK_URL`，如：`OBJECT_STORAGE_CALLBACK_URL=http://your_domain.com/extends/ObjectStorage/callBack`   

--- a/src/Lib/Common.php
+++ b/src/Lib/Common.php
@@ -89,7 +89,11 @@ class Common
         $title && $params['title'] = $title;
         $hash_id && $params['hash_id'] = $hash_id;
         $resize && $params['resize'] = $resize;
-        return U('/extends/ObjectStorage/callBack',$params,true,true);
+
+        $query = http_build_query($params);
+        // return U('/extends/ObjectStorage/callBack',$params,true,true);
+        $site_url = env('OBJECT_STORAGE_CALLBACK_URL', U('/extends/ObjectStorage/callBack',[],true,true));
+        return $site_url.'?'.$query;
     }
 
     public static function genObjectName($config, $ext = ''):string{


### PR DESCRIPTION
在 Common 类中修改了回调地址的生成逻辑，现在可以通过 `.env` 文件中的
OBJECT_STORAGE_CALLBACK_URL 配置项来自定义回调地址。如果未配置，则默认使用原有的回调地址生成方式。